### PR TITLE
Add port and open to devServer config in webpack

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -55,9 +55,12 @@ const devConfig = {
   plugins: [new HtmlWebpackPlugin({
     template: path.resolve(__dirname, 'public/index.html'),
     filename: 'index.html'
-  })]
+  })],
+  devServer: {
+    open: true,
+    port: 3000
+  }
 };
-
 
 
 const mainConfig =  {


### PR DESCRIPTION
This is meant to set the port number and auto-open the browser when running yarn dev